### PR TITLE
Changed HashMap to ConcurrentHashMap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 
 group = 'com.github.hmongkey12'
-version = '1.0.0'
+version = '1.0.2'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
@@ -37,7 +37,7 @@ bootJar.enabled = false
 
 jar {
     archiveBaseName.set('league-shared-types')
-    archiveVersion.set('1.0.0')
+    archiveVersion.set('1.0.2')
     archiveClassifier.set(null)
 }
 

--- a/src/main/java/com/serializers/SerializableAbilityEntity.java
+++ b/src/main/java/com/serializers/SerializableAbilityEntity.java
@@ -9,9 +9,9 @@ import java.io.Serializable;
 @Builder
 public class SerializableAbilityEntity implements Serializable {
     private String abilityName;
-    private float abilityStart;
     private float abilityEnd;
     private float cooldownEnd;
+    private float abilityStart;
     private float cooldownStart;
     private float damage;
     int xPos;

--- a/src/main/java/com/serializers/SerializableGameState.java
+++ b/src/main/java/com/serializers/SerializableGameState.java
@@ -4,14 +4,14 @@ import lombok.Data;
 import org.springframework.stereotype.Component;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Data
 @Component
 public class SerializableGameState implements Serializable {
     Map<String, SerializableHeroEntity> connectedPlayers;
     public SerializableGameState() {
-       this.connectedPlayers = new HashMap<String, SerializableHeroEntity> ();
+       this.connectedPlayers = new ConcurrentHashMap<String, SerializableHeroEntity> ();
     }
 }

--- a/src/main/java/com/serializers/SerializableHeroEntity.java
+++ b/src/main/java/com/serializers/SerializableHeroEntity.java
@@ -20,11 +20,11 @@ public class SerializableHeroEntity implements Serializable {
     private String id;
     private boolean isFalling;
     private boolean isJumping;
-    private float jumpStart;
     private int health;
     private float movingStart;
-    private float movingEnd;
+    private float jumpStart;
     private float attackStart;
+    private float movingEnd;
     private float attackEnd;
     private String facingDirection;
 }

--- a/src/test/java/com/serializers/BasicSerializerTest.java
+++ b/src/test/java/com/serializers/BasicSerializerTest.java
@@ -3,8 +3,9 @@ package com.serializers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
-public class BasicSerializerTest {
+import java.time.Instant;
 
+public class BasicSerializerTest {
     @Test
     public void testSerializeAndDeserialize() throws Exception {
         // Create an object to serialize and deserialize


### PR DESCRIPTION
This PR modifies the initialization of the connectedPlayers Map inside of SerializableGameState.  The Map was initialized to HashMap, but because the server needs to be able to listen for player update requests and detect a disconnect from the player, an ExecutorScheduler was added to schedule tasks, and requires thread safety since the gameState is being shared between the update request and the method that listens for player disconnect.  As a result, Map is now initialized to ConcurrentHashMap.